### PR TITLE
[Feature] 에러 로깅 시스템 구축

### DIFF
--- a/BE/src/main/java/io/github/hayo02/proxyshopping/exception/GlobalExceptionHandler.java
+++ b/BE/src/main/java/io/github/hayo02/proxyshopping/exception/GlobalExceptionHandler.java
@@ -1,12 +1,26 @@
 package io.github.hayo02.proxyshopping.exception;
 
 import io.github.hayo02.proxyshopping.common.ApiResponse;
+import io.github.hayo02.proxyshopping.orders.service.SlackNotificationService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.*;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    private final SlackNotificationService slackNotificationService;
+
+    public GlobalExceptionHandler(SlackNotificationService slackNotificationService) {
+        this.slackNotificationService = slackNotificationService;
+    }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex){
@@ -20,7 +34,22 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex){
+    public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex, HttpServletRequest request){
+        log.error("서버 오류 발생 - URI: {}, 오류: {}", request.getRequestURI(), ex.getMessage(), ex);
+
+        // Slack으로 에러 알림 전송
+        try {
+            StringWriter sw = new StringWriter();
+            ex.printStackTrace(new PrintWriter(sw));
+            slackNotificationService.sendErrorNotification(
+                    ex.getMessage(),
+                    sw.toString(),
+                    request.getRequestURI()
+            );
+        } catch (Exception e) {
+            log.error("Slack 에러 알림 전송 중 오류: {}", e.getMessage());
+        }
+
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error("서버 오류가 발생했습니다."));
     }

--- a/BE/src/main/java/io/github/hayo02/proxyshopping/orders/service/SlackNotificationService.java
+++ b/BE/src/main/java/io/github/hayo02/proxyshopping/orders/service/SlackNotificationService.java
@@ -10,4 +10,12 @@ public interface SlackNotificationService {
      * @param quotationFilePath 견적서 파일 경로
      */
     void sendPaymentCompleteNotification(Order order, String quotationFilePath);
+
+    /**
+     * 서버 에러 발생 시 Slack으로 알림을 전송합니다.
+     * @param errorMessage 에러 메시지
+     * @param stackTrace 스택 트레이스
+     * @param requestUri 요청 URI
+     */
+    void sendErrorNotification(String errorMessage, String stackTrace, String requestUri);
 }


### PR DESCRIPTION
## 관련 Issue
Closes #3

## 변경 사항
- GlobalExceptionHandler에 Slack 에러 알림 기능 추가
- SlackNotificationService에 sendErrorNotification 메서드 추가
- 서버 에러 발생 시 Slack으로 자동 알림 전송
- 에러 메시지, 스택 트레이스(500자), 요청 URI 포함

## 테스트
- [x] 로컬에서 테스트 완료
- [x] 빌드 성공 확인